### PR TITLE
Fixed error in deleting from myPosts

### DIFF
--- a/Tabloid/client/src/components/post/MyPosts.js
+++ b/Tabloid/client/src/components/post/MyPosts.js
@@ -15,7 +15,7 @@ const MyPosts = () => {
     let yes = window.confirm("Are you sure you want to delete this post?")
     if (yes === true) {
       deletePost(id)
-        .then(getAllUserPosts())
+        .then(fetchUserPosts())
     }
   }
 


### PR DESCRIPTION
# Description
Fixed issues with myPosts not re-rendering when a post has been deleted.

Fixes # 
Auto rendering of myPosts
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions
Navigate to myPosts page, select to delete a post and the page should be re-rendered and no longer display the deleted posts.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works